### PR TITLE
Replace text fields with rich text fields

### DIFF
--- a/.slicemachine/assets/customtypes/league_table/mocks.json
+++ b/.slicemachine/assets/customtypes/league_table/mocks.json
@@ -19,13 +19,25 @@
       },
       "alt": null,
       "copyright": null,
-      "url": "https://images.unsplash.com/photo-1551739440-5dd934d3a94a"
+      "url": "https://images.unsplash.com/photo-1600804931749-2da4ce26c869"
     },
     "variant": "northernMagenta",
     "table": [
       {
-        "position": "1st",
-        "team": "London Quidditch Club"
+        "position": [
+          {
+            "type": "paragraph",
+            "text": "Veniam fugiat ex veniam Lorem irure dolor in magna.",
+            "spans": []
+          }
+        ],
+        "team": [
+          {
+            "type": "paragraph",
+            "text": "Anim ut occaecat aliquip irure proident dolore proident mollit pariatur voluptate culpa esse eiusmod deserunt. Ex enim do dolor non nulla adipisicing velit laboris. Aliquip voluptate labore sint Lorem nisi anim pariatur do labore sit.",
+            "spans": []
+          }
+        ]
       }
     ]
   }

--- a/.slicemachine/libraries-state.json
+++ b/.slicemachine/libraries-state.json
@@ -103,7 +103,7 @@
         },
         "screenshotPaths": {
           "default": {
-            "path": "/Users/declan.ramsay/Documents/dev/quidditch/chaser/.slicemachine/assets/slices/LeagueTables/default/preview.png",
+            "path": "C:\\Users\\Michal\\Desktop\\Projects\\QUK\\chaser\\.slicemachine\\assets\\slices\\LeagueTables\\default\\preview.png",
             "width": 800,
             "height": 193
           }

--- a/.slicemachine/mock-config.json
+++ b/.slicemachine/mock-config.json
@@ -40,10 +40,16 @@
     "league_table": {
       "table": {
         "position": {
-          "content": "1st"
+          "config": {
+            "patternType": "PARAGRAPH",
+            "blocks": 1
+          }
         },
         "team": {
-          "content": "London Quidditch Club"
+          "config": {
+            "patternType": "PARAGRAPH",
+            "blocks": 1
+          }
         }
       },
       "title": {

--- a/customtypes/league_table/index.json
+++ b/customtypes/league_table/index.json
@@ -46,17 +46,21 @@
           "label": "Table",
           "fields": {
             "position": {
-              "type": "Text",
+              "type": "StructuredText",
               "config": {
                 "label": "position",
-                "placeholder": ""
+                "placeholder": "1st",
+                "allowTargetBlank": true,
+                "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
               }
             },
             "team": {
-              "type": "Text",
+              "type": "StructuredText",
               "config": {
                 "label": "Team",
-                "placeholder": ""
+                "placeholder": "LQC",
+                "allowTargetBlank": true,
+                "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
               }
             }
           }

--- a/slices/LeagueTables/index.js
+++ b/slices/LeagueTables/index.js
@@ -101,10 +101,10 @@ const LeagueTableCard = ({ table }) => {
           {data?.table?.map((item) => (
             <Fragment key={`league-table--${item.position}-${item.team}`}>
               <Box {...dividedCellStyles} bg="white">
-                {item?.position}
+                <PrismicRichText field={data.table.position} />
               </Box>
               <Box {...dividedCellStyles} bg="white" px={2}>
-                {item?.team}
+                <PrismicRichText field={data.table.team} />
               </Box>
             </Fragment>
           ))}


### PR DESCRIPTION
https://github.com/QuidditchUK/chaser/issues/281

I ran slice machine locally, removed the old text fields of position and team, and added rich text fields named the same. Then saved to file system, and changed the React code to use `PrismicRichText`.

Is there some place where I can see it in action on the website? I had a quick search, but no easy dice. 