### PR TITLE
Banned users

### DIFF
--- a/components/permissions/permissions-block.tsx
+++ b/components/permissions/permissions-block.tsx
@@ -45,11 +45,13 @@ const PermissionBlock = ({
   scope,
   userScopes,
   actionScopes,
+  allowEditing,
 }: {
   label: string;
   scope: string;
   userScopes: string[];
   actionScopes: string[]; // scope with permission to add/remove
+  allowEditing: boolean; // whether the block allows editing scopes
 }) => {
   const {
     register,
@@ -82,7 +84,9 @@ const PermissionBlock = ({
       <Box bg="white" borderRadius="lg">
         <Table
           name={scope}
-          columns={['Name', 'Scopes', 'Actions']}
+          columns={
+            allowEditing ? ['Name', 'Scopes', 'Actions'] : ['Name', 'Scopes']
+          }
           isLoading={isLoading}
           tableProps={{
             sx: {
@@ -100,7 +104,7 @@ const PermissionBlock = ({
                 {user?.first_name} {user?.last_name}
               </Td>
               <Td>{user?.scopes.map(({ scope }) => scope).join(', ')}</Td>
-              {hasScope(actionScopes, userScopes) && (
+              {hasScope(actionScopes, userScopes) && allowEditing && (
                 <Td textAlign="right">
                   <Flex direction="row" justifyContent="flex-end" gap={3}>
                     <Button

--- a/constants/scopes.ts
+++ b/constants/scopes.ts
@@ -3,6 +3,7 @@ export const VOLUNTEER = 'volunteer';
 export const EMT = 'emt';
 export const HEAD_SCOUT = 'head-scout';
 export const CLUB_MANAGEMENT = 'club-management';
+export const BANNED = 'banned';
 
 export const USERS_READ = 'users:read';
 export const CLUBS_READ = 'clubs:read';

--- a/pages/admin/permissions.tsx
+++ b/pages/admin/permissions.tsx
@@ -1,6 +1,6 @@
 import { Flex, Box } from '@chakra-ui/react';
 
-import { ADMIN, EMT, HEAD_SCOUT, VOLUNTEER } from 'constants/scopes';
+import { ADMIN, BANNED, EMT, HEAD_SCOUT, VOLUNTEER } from 'constants/scopes';
 import { getPlainScopes } from 'modules/scopes';
 import { isScoped_ServerProps } from 'modules/auth';
 import { getBasePageProps } from 'modules/prismic';
@@ -39,24 +39,35 @@ const Permissions = () => {
             scope={EMT}
             userScopes={userScopes}
             actionScopes={[ADMIN]}
+            allowEditing={true}
           />
           <PermissionBlock
             label="Admin"
             scope={ADMIN}
             userScopes={userScopes}
             actionScopes={[ADMIN]}
+            allowEditing={true}
           />
           <PermissionBlock
             label="Head Scout"
             scope={HEAD_SCOUT}
             userScopes={userScopes}
             actionScopes={[ADMIN, EMT]}
+            allowEditing={true}
           />
           <PermissionBlock
             label="Volunteers"
             scope={VOLUNTEER}
             userScopes={userScopes}
             actionScopes={[ADMIN, EMT]}
+            allowEditing={true}
+          />
+          <PermissionBlock
+            label="Banned users (not reversible)"
+            scope={BANNED}
+            userScopes={userScopes}
+            actionScopes={[ADMIN]}
+            allowEditing={false}
           />
         </Slice>
       </SkeletonLoaderWrapper>

--- a/pages/api/scopes/[scope]/users/[uuid].ts
+++ b/pages/api/scopes/[scope]/users/[uuid].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { isScoped_ApiRoute } from 'modules/auth';
-import { ADMIN, EMT, CLUB_MANAGEMENT } from 'constants/scopes';
+import { ADMIN, EMT, CLUB_MANAGEMENT, BANNED } from 'constants/scopes';
 import { getToken } from 'next-auth/jwt';
 import prisma from 'modules/prisma';
 
@@ -26,6 +26,13 @@ export default async function handler(
 
         // Only admins can remove EMT + Admin scopes
         if ([ADMIN, EMT].includes(scope) && !userScopes.includes(ADMIN)) {
+          res.status(403).end();
+          return;
+        }
+
+        // Nobody can unban users (it's not a reversible action)
+        // To make it reversible we need to have a record of what the user had before banning - products, club memberships, etc.
+        if (scope === BANNED) {
           res.status(403).end();
           return;
         }

--- a/pages/api/scopes/index.ts
+++ b/pages/api/scopes/index.ts
@@ -46,18 +46,24 @@ export default async function handler(
         });
 
         if (scope === BANNED) {
-          await prisma.users_stripe_products.deleteMany({
-            where: { user_uuid },
-          });
-          await prisma.teams_users.deleteMany({
-            where: { user_uuid },
-          });
-          await prisma.scouting_requests.deleteMany({
-            where: { user_uuid },
-          });
-          await prisma.student_summer_pass.deleteMany({
-            where: { user_uuid },
-          });
+          await Promise.all([
+            prisma.users_stripe_products.deleteMany({
+              where: { user_uuid },
+            }),
+            prisma.teams_users.deleteMany({
+              where: { user_uuid },
+            }),
+            prisma.scouting_requests.deleteMany({
+              where: { user_uuid },
+            }),
+            prisma.student_summer_pass.deleteMany({
+              where: { user_uuid },
+            }),
+            prisma.users.update({
+              where: { uuid: user_uuid },
+              data: { club_uuid: null },
+            }),
+          ]);
         }
 
         res.status(201).end();

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -7,6 +7,7 @@ import {
   Link as ChakraLink,
   Skeleton,
   Grid,
+  useToast,
 } from '@chakra-ui/react';
 
 import { getBasePageProps } from 'modules/prismic';
@@ -44,11 +45,20 @@ const Dashboard = () => {
   const { push } = useRouter();
 
   const userScopes = getPlainScopes(user?.scopes);
+  const toast = useToast();
 
-  // QQ commonise
-  // QQ Some information to the user that their account has been banned?
   const handleSignOut = async () => {
     const data = await signOut({ redirect: false, callbackUrl: '/' });
+    toast({
+      title: 'Account banned',
+      description:
+        'Your account has been banned. If you think this is a mistake, please contact us via https://quadballuk.org/about/contact-us',
+      status: 'error',
+      duration: 5000,
+      position: 'top',
+      variant: 'left-accent',
+      isClosable: true,
+    });
     push(data?.url);
   };
 

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -24,6 +24,11 @@ import { clubs as Club } from '@prisma/client';
 import Stripe from 'stripe';
 import useMe from 'hooks/useMe';
 import SkeletonLoaderWrapper from 'components/shared/SkeletonLoaderWrapper';
+import { getPlainScopes } from 'modules/scopes';
+import { BANNED } from 'constants/scopes';
+import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 const Container = dynamic(() => import('components/layout/container'));
 
@@ -36,6 +41,22 @@ const PrismicClubCard = dynamic(() => import('components/prismic/club-card'));
 
 const Dashboard = () => {
   const { data: user, isLoading } = useMe();
+  const { push } = useRouter();
+
+  const userScopes = getPlainScopes(user?.scopes);
+
+  // QQ commonise
+  // QQ Some information to the user that their account has been banned?
+  const handleSignOut = async () => {
+    const data = await signOut({ redirect: false, callbackUrl: '/' });
+    push(data?.url);
+  };
+
+  useEffect(() => {
+    if (userScopes && userScopes.includes(BANNED)) {
+      handleSignOut();
+    }
+  }, [userScopes]);
 
   const { data: memberships } = useCachedResponse<Stripe.Product[]>({
     queryKey: '/products/me',


### PR DESCRIPTION
This adds a scope for banning users. 

It uses existing permissions page and components to ban users.

I think as banning is an inherently destructive operation. I'm not sure if we should take some sort of snapshot before deleting their memberships, team affiliations and so on. In any case, automatic unbanning would require a bunch more work - like deactivating memberships, and reactivating them if the user is unbanned. Let me know if I should look at it.

Since banning is currently not reversible, I hid actions from the permissions component that displays banned users.
![image](https://user-images.githubusercontent.com/18363821/232618246-fad4d364-943c-4faa-b014-5b1597a6a309.png)

One question (and so QQs in the code): when we log the user in, and we detect they are banned, we log them out right after. Should they get a pop up, or get redirected to some sort of page telling them that they have been banned and to contact us if they think it was a mistake or something? 